### PR TITLE
Prevent default click event from happening

### DIFF
--- a/contextMenu.js
+++ b/contextMenu.js
@@ -24,7 +24,8 @@ angular.module('ui.bootstrap.contextMenu', [])
                 $a.attr({ tabindex: '-1', href: '#' });
                 $a.text(typeof item[0] == 'string' ? item[0] : item[0].call($scope, $scope));
                 $li.append($a);
-                $li.on('click', function () {
+                $li.on('click', function ($event) {
+                    $event.preventDefault();
                     $scope.$apply(function () {
                         $(event.currentTarget).removeClass('context');
                         $contextMenu.remove();


### PR DESCRIPTION
When clicking a menu item while scrolled down a bit, the page jumps up to the top. The `#` in the URL is only visible for a second, but it happens.

This is so the page doesn't jump up to the top after clicking a menu item.

Thanks!
