### PR TITLE
Allow icons (as HTML) in menu item.

### DIFF
--- a/contextMenu.js
+++ b/contextMenu.js
@@ -23,7 +23,7 @@ angular.module('ui.bootstrap.contextMenu', [])
                 var $a = $('<a>');
                 $a.attr({ tabindex: '-1', href: '#' });
                 var text = typeof item[0] == 'string' ? item[0] : item[0].call($scope, $scope, event, model);
-                $a.text(text);
+                $a.html(text);
                 $li.append($a);
                 var enabled = angular.isDefined(item[2]) ? item[2].call($scope, $scope, event, text, model) : true;
                 if (enabled) {


### PR DESCRIPTION
This way one can use icons in the menu elements like 

```
      $scope.menuOptions = function(program) {
        return [
          [function() {return '<i class="fa fa-fw fa-pencil"></i> edit'},
            function ($itemScope) { console.log('edit') } ],
        ];
      };
```

If this shouldn't be the default I'd suggest a 4th parameter to each element containing options, to be open for future extensions:
```
      $scope.menuOptions = function(program) {
        return [
          [function() {return '<i class="fa fa-fw fa-pencil"></i> edit'},
            function ($itemScope) { console.log('edit') },
            true,
            {allowHtml: true}
          ],
        ];
      };
```