### PR TITLE
uncomment $event.preventDefault();

### DIFF
--- a/contextMenu.js
+++ b/contextMenu.js
@@ -69,7 +69,7 @@ angular.module('ui.bootstrap.contextMenu', [])
                         renderContextMenu($scope, ev, nestedMenu, model, level + 1);
                     }
                     $li.on('click', function ($event) {
-                        //$event.preventDefault();
+                        $event.preventDefault();
                         $scope.$apply(function () {
                             if (nestedMenu) {
                                 openNestedMenu($event);


### PR DESCRIPTION
if not prevented, the page will go to #, this causes unwanted behaviour like scrolling back to the top