### PR TITLE
Ability to Create Multiple Opening Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ Add a reference to `contextMenu.js`. In your app config add `ui.bootstrap.contex
 </div>
 <div ng-bind="selected"></div>
 ```
+
+* OR
+
+```html
+<div>
+    <span>you can specify the event on how the menu opens:</span>
+    <div ng-repeat="item in items" context-menu="menuOptions" context-menu-on="contextmenu,click">Left and Right Click: {{item.name}}</div>
+</div>
+<div ng-bind="selected"></div>
+```
+
 ### Callback Parameters
 
 There are currently 5 parameters that are being passed to the callback:

--- a/contextMenu.js
+++ b/contextMenu.js
@@ -268,10 +268,10 @@ angular.module('ui.bootstrap.contextMenu', [])
         }
 
         function removeOnOutsideClickEvent(e) {
-          
+
           var $curr = $(e.target);
           var shouldRemove = true;
-          
+
           while($curr.length) {
             if($curr.hasClass("dropdown-menu")) {
               shouldRemove = false;
@@ -311,33 +311,36 @@ angular.module('ui.bootstrap.contextMenu', [])
     }
 
     return function ($scope, element, attrs) {
-        var openMenuEvent = "contextmenu";
+        var openMenuEvent = ["contextmenu"];
         if(attrs.contextMenuOn && typeof(attrs.contextMenuOn) === "string"){
-            openMenuEvent = attrs.contextMenuOn;
+            openMenuEvent = attrs.contextMenuOn.split(",");
         }
-        element.on(openMenuEvent, function (event) {
-            if(!attrs.allowEventPropagation) {
-              event.stopPropagation();
-              event.preventDefault();
-            }
 
-            // Don't show context menu if on touch device and element is draggable
-            if(isTouchDevice() && element.attr('draggable') === 'true') {
-              return false;
-            }
-
-            $scope.$apply(function () {
-                var options = $scope.$eval(attrs.contextMenu);
-                var customClass = attrs.contextMenuClass;
-                var modelValue = $scope.$eval(attrs.model);
-                if (options instanceof Array) {
-                    if (options.length === 0) { return; }
-                    renderContextMenu($scope, event, options, modelValue, undefined, customClass);
-                } else {
-                    throw '"' + attrs.contextMenu + '" not an array';
+        for (var i = 0; i < openMenuEvent.length; ++i) {
+            element.on(openMenuEvent[i], function (event) {
+                if(!attrs.allowEventPropagation) {
+                  event.stopPropagation();
+                  event.preventDefault();
                 }
+
+                // Don't show context menu if on touch device and element is draggable
+                if(isTouchDevice() && element.attr('draggable') === 'true') {
+                  return false;
+                }
+
+                $scope.$apply(function () {
+                    var options = $scope.$eval(attrs.contextMenu);
+                    var customClass = attrs.contextMenuClass;
+                    var modelValue = $scope.$eval(attrs.model);
+                    if (options instanceof Array) {
+                        if (options.length === 0) { return; }
+                        renderContextMenu($scope, event, options, modelValue, undefined, customClass);
+                    } else {
+                        throw '"' + attrs.contextMenu + '" not an array';
+                    }
+                });
             });
-        });
+        }
     };
 }]);
 


### PR DESCRIPTION
I ended up with a use-case where I needed the menu to be able to be opened by either a right or left click. The modifications I've made will allow for any number of open events by allowing you to send a comma delimited list in your html.

For example:

```html
<div ng-repeat="item in items" context-menu="menuOptions" context-menu-on="click,contextmenu">Left and Right Click: {{item.name}}</div>
```