### PR TITLE
Add ignoreForClass attribute that aborts contextmenu if applied

### DIFF
--- a/contextMenu.js
+++ b/contextMenu.js
@@ -326,6 +326,11 @@ angular.module('ui.bootstrap.contextMenu', [])
               return false;
             }
 
+            // Don't show context menu when element has certain class
+            if(attrs.ignoreForClass && element.hasClass(attrs.ignoreForClass)) {
+              return false;
+            }
+
             $scope.$apply(function () {
                 var options = $scope.$eval(attrs.contextMenu);
                 var customClass = attrs.contextMenuClass;


### PR DESCRIPTION
* If the element has the ignoreForClass the context menu won't be shown

This adds ability to dynamically disable contextMenu

Example:

<div context-menu="" ignore-for-class="some-class" />

If the div has "some-class" the context-menu won't show.