### PR TITLE
Feature: Passing the event object as $event in dynamic menus

### DIFF
--- a/contextMenu.js
+++ b/contextMenu.js
@@ -318,7 +318,7 @@ angular.module('ui.bootstrap.contextMenu', [])
             }
 
             $scope.$apply(function () {
-                var options = $scope.$eval(attrs.contextMenu);
+                var options = $scope.$eval(attrs.contextMenu, {$event: event});
                 var customClass = attrs.contextMenuClass;
                 var modelValue = $scope.$eval(attrs.model);
                 if (options instanceof Array) {


### PR DESCRIPTION
This allows the event object to be passed to the callback function when using dynamically generated context menus, before selecting any option. It is useful if you want to evaluate the event properties when creating the menu.

Demo: http://codepen.io/anon/pen/gmLezP
In order to show the 'Buy' option you have to [ctrl+right click]