### PR TITLE
fix submenus not clearing

### DIFF
--- a/contextMenu.js
+++ b/contextMenu.js
@@ -204,22 +204,23 @@ angular.module('ui.bootstrap.contextMenu', [])
                 }
             });
 
-            $li.on('mouseover', function ($event) {
-                $scope.$apply(function () {
-                    if (nestedMenu) {
-                        openNestedMenu($event);
-                    /// Implementation made by dashawk
-                    } else {
-                        removeContextMenus(level + 1);
-                    }
-                });
-            });
         } else {
             $li.on('click', function ($event) {
                 $event.preventDefault();
             });
             $li.addClass('disabled');
         }
+
+		$li.on('mouseover', function ($event) {
+			$scope.$apply(function () {
+				if (nestedMenu) {
+					openNestedMenu($event);
+				/// Implementation made by dashawk
+				} else {
+					removeContextMenus(level + 1);
+				}
+			});
+		});
 
     };
 


### PR DESCRIPTION
even after implementing @dashawk's changes, submenus were not clearing (I cannot provide example code but this happened in the demo page, even). this patch fixes it the issue, for me at least.

apparently the listener was not being attached to disabled elements, which does not make sense as even disabled elements would still be outside the boundaries of the parent list item of the submenu.