### PR TITLE
feature: support dynamic subitems 

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Every menu option is represented by an Object containing the following propertie
 - text - [Function/String] A function that returns the string or the actual string itself
 - click - [Function] The function to be called on click of the option
 - enabled - [Function/Boolean] A function returning whether the option is enabled or not, or a boolean
-- children - [Array] An Array of options that will appear as the submenu of the current option
+- children - [Array/Promise] An Array of menu options that will appear as the submenu of the current option, or a Promise resolving to a Function which can provide menu options dynamically
 
 ### Legacy implementation (still supported, but will not be updated any longer)
 Every menu option has an array with 2-3 indexs. Most items will use the `[String, Function]` format. If you need a dynamic item in your context menu you can also use the `[Function, Function]` format.

--- a/contextMenu.js
+++ b/contextMenu.js
@@ -169,6 +169,10 @@ angular.module('ui.bootstrap.contextMenu', [])
                  * Regardless, passing them to `when` makes the implementation singular.
                  */
                 $q.when(nestedMenu).then(function(promisedNestedMenu) {
+                    if (angular.isFunction(promisedNestedMenu)) {
+                        //  support for dynamic subitems
+                        promisedNestedMenu = promisedNestedMenu.call($scope, $scope, event, modelValue, text, $li);
+                    }
                     var nestedParam = {
                       "$scope" : $scope,
                       "event" : ev,


### PR DESCRIPTION
With this PR we should be able to provide an array of submenu options dynamically, like so:

```javascript
children: $q(function (resolve) {
    resolve(
        function ($itemScope) {
            return service.prepareSubItems($itemScope, jumpOptions);
        }
    );
})
```