### PR TITLE
Add ability to close menu on touch devices

### DIFF
--- a/contextMenu.js
+++ b/contextMenu.js
@@ -510,7 +510,7 @@
         }
 
         function removeAllContextMenus(e) {
-          $document.find('body').off('mousedown', removeOnOutsideClickEvent);
+          $document.find('body').off('mousedown touchstart', removeOnOutsideClickEvent);
           $document.off('scroll', removeOnScrollEvent);
           $(_clickedElement).removeClass('context');
           removeContextMenus();
@@ -579,7 +579,7 @@
               }
 
               // Remove if the user clicks outside
-              $document.find('body').on('mousedown', removeOnOutsideClickEvent);
+              $document.find('body').on('mousedown touchstart', removeOnOutsideClickEvent);
               // Remove the menu when the scroll moves
               $document.on('scroll', removeOnScrollEvent);
 


### PR DESCRIPTION
This touch event will close the open menu by clicking outside it.