### PR TITLE
chore: set version to 1.2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "angular-bootstrap-contextmenu",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "main": [
         "contextMenu.js"
     ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-bootstrap-contextmenu",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Angular Bootstrap Context Menu",
   "main": "contextMenu.js",
   "scripts": {


### PR DESCRIPTION
Hey there, as explained  here (#141) and tested by @hieutranagi47 and me, latests changes to the repository weren't downloaded when using bower install. Checking [docs](https://bower.io/docs/creating-packages/) at bower I see that it needed a bump version and adding a tag "v1.2.0".

Please add the **v1.2.0** tag when merged, since pull requests doesn't include them.